### PR TITLE
Proposal to upgrade Rebus reference to v6.3.1 (the latest version to date)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ A Rebus-powered event dispatcher for MementoFX
 
 **Release notes**
 
+Version 2.0.1-pre1
+- Rebus reference upgraded to v6.3.1
+
 Version 2.0.0
 - MementoFX reference updated to v2.0.0 GA
 - Rebus reference upgraded to v5.0.1

--- a/src/MementoFX.Messaging.Rebus.Tests/MementoFX.Messaging.Rebus.Tests.csproj
+++ b/src/MementoFX.Messaging.Rebus.Tests/MementoFX.Messaging.Rebus.Tests.csproj
@@ -4,7 +4,7 @@
     <Product>MementoFX</Product>
     <Company>Managed Designs</Company>
     <Authors>Andrea Saltarello, Managed Designs</Authors>
-    <Version>2.0.0</Version>
+    <Version>2.0.1-pre1</Version>
     <Copyright>© 2013-2018 Andrea Saltarello, Managed Designs</Copyright>
     <PackageProjectUrl>https://opensource.manageddesigns.it/mementofx</PackageProjectUrl>
     <PackageLicenseUrl>https://opensource.org/licenses/RPL-1.5</PackageLicenseUrl>
@@ -33,7 +33,7 @@
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.3.1" />
     <PackageReference Include="MementoFX" Version="2.0.0" />
-    <PackageReference Include="Rebus" Version="5.0.1" />
+    <PackageReference Include="Rebus" Version="6.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Moq" Version="4.10.0" />
     <PackageReference Include="SharpTestsEx" Version="2.0.0" />

--- a/src/MementoFX.Messaging.Rebus/MementoFX.Messaging.Rebus.csproj
+++ b/src/MementoFX.Messaging.Rebus/MementoFX.Messaging.Rebus.csproj
@@ -11,7 +11,7 @@
     <PackageTags>mementofx, mementofx, rebus, bus, cqrs, ddd</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <Version>2.0.0</Version>
+    <Version>2.0.1-pre1</Version>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -34,7 +34,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MementoFX" Version="2.0.0" />
-    <PackageReference Include="Rebus" Version="5.0.1" />
+    <PackageReference Include="Rebus" Version="6.3.1" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />


### PR DESCRIPTION
Made a fork just to propose the upgrade of Rebus reference to v6.3.1. It seems a pretty smooth change as per tests conducted with MementoFX and MementoFX.Persistence.MongoDB (latest versions available to date).

Thanks
-Gian